### PR TITLE
Remove excess padding in searchKit buttons

### DIFF
--- a/css/bootstrap3.css
+++ b/css/bootstrap3.css
@@ -28,8 +28,7 @@
 	padding: 0;
 }
 #bootstrap-theme .btn-default, 
-#bootstrap-theme .btn,
-#bootstrap-theme.crm-search .btn {
+#bootstrap-theme .btn {
 	padding: 0 10px 0 20px;
 	background-color: var(--vvv-light-gray);
 	color: var(--vvv-dark-gray);


### PR DESCRIPTION
Before
--------
![image](https://user-images.githubusercontent.com/2874912/107796867-50675200-6d28-11eb-8206-6982d0c80e44.png)


After
-----
![image](https://user-images.githubusercontent.com/2874912/107796684-244bd100-6d28-11eb-8452-42daceea9909.png)


PS
---

I'm not sure I understand the motivation for any SearchKit tweaks. SearchKit is a beta UI and intended to work with vanilla Bootstrap. I'd be tempted to remove all of this. The tweaks I *would* like to see in this extension are the ones from this file (note each rule in the file would be prefixed with `#bootstrap-theme` by the SCSS compiler):

https://github.com/civicrm/civicrm-core/blob/cd4fec5894870d15d21c908181ff7cf35db5b277/ext/greenwich/scss/_tweaks.scss