### PR TITLE
Theme weight

### DIFF
--- a/finsburypark.php
+++ b/finsburypark.php
@@ -18,6 +18,10 @@ function finsburypark_civicrm_config(&$config) {
 
 function finsburypark_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) {
   $theme = Civi::service('themes')->getActiveThemeKey();
+  if ($theme !== 'finsburypark') {
+    return;
+  }
+
   switch ($theme . ':' . $bundle->name) {
     case 'finsburypark:bootstrap3':
       $bundle->clear();
@@ -29,6 +33,15 @@ function finsburypark_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) {
         'translate' => FALSE,
       ]);
       break;
+  }
+  if ($bundle->name == 'coreStyles') {
+    $bundle->filter(function($snippet) {
+      if ($snippet['name'] == 'civicrm:css/civicrm.css') {
+        $snippet['weight'] = 90;
+        return $snippet;
+      }
+      return TRUE;
+    });
   }
 }
 

--- a/finsburypark.php
+++ b/finsburypark.php
@@ -37,7 +37,11 @@ function finsburypark_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) {
   if ($bundle->name == 'coreStyles') {
     $bundle->filter(function($snippet) {
       if ($snippet['name'] == 'civicrm:css/civicrm.css') {
-        $snippet['weight'] = 90;
+        $snippet['weight'] = 290;
+        return $snippet;
+      }
+      elseif (($snippet['name'] == 'civicrm::css/custom.css') or (strpos($snippet['name'], 'custom.css') !== false)) {
+        $snippet['weight'] = 300;
         return $snippet;
       }
       return TRUE;

--- a/finsburypark.theme.php
+++ b/finsburypark.theme.php
@@ -6,13 +6,6 @@ return array (
   'title' => 'Finsbury Park',
   'prefix' => NULL,
   'url_callback' => '\\Civi\\Core\\Themes\\Resolvers::simple',
-  'search_order' => 
-  array (
-    0 => 'finsburypark',
-    1 => '_fallback_',
-  ),
-  'excludes' => 
-  array (
-	  0 => 'css/bootstrap.css',
-  ),
+  'search_order' => ['finsburypark', '_fallback_'],
+  'excludes' => ['css/bootstrap.css'],
 );


### PR DESCRIPTION
Change the css file loading order so that the theme css overrides the other core css files.  The theme's css is still overridden by the Custom CSS setting allowing for local tweaks.

Depending on the progress of https://lab.civicrm.org/dev/core/-/issues/2460 this might become redundant.