### PR TITLE
Fix typo in snippet name

### DIFF
--- a/finsburypark.php
+++ b/finsburypark.php
@@ -40,7 +40,7 @@ function finsburypark_civicrm_alterBundle(CRM_Core_Resources_Bundle $bundle) {
         $snippet['weight'] = 290;
         return $snippet;
       }
-      elseif (($snippet['name'] == 'civicrm::css/custom.css') or (strpos($snippet['name'], 'custom.css') !== false)) {
+      elseif (($snippet['name'] == 'civicrm:css/custom.css') or (strpos($snippet['name'], 'custom.css') !== false)) {
         $snippet['weight'] = 300;
         return $snippet;
       }


### PR DESCRIPTION
The new 'name' for the custom.css has been merged to core: https://github.com/civicrm/civicrm-core/pull/20278